### PR TITLE
NumberGroup: implement parser properly

### DIFF
--- a/parsers/number.go
+++ b/parsers/number.go
@@ -26,7 +26,29 @@ func (n *NumberGroup) CanParseIntoHuman(s string) bool {
 
 // CanParseFromHuman ...
 func (n *NumberGroup) CanParseFromHuman(s string) bool {
-	return false
+
+	conds := []func(string) bool{
+		// Should at least be the number 1 thousand
+		func(s string) bool {
+			return len(s) >= 4
+		},
+		// Can't have letters in it
+		func(s string) bool {
+			match, _ := regexp.MatchString(`[a-z]+`, s)
+			return !match
+		},
+		// Needs to have a comma in it
+		func(s string) bool {
+			return strings.Contains(s, ",")
+		},
+	}
+
+	for _, c := range conds {
+		if c(s) == false {
+			return false
+		}
+	}
+	return true
 }
 
 // DoIntoHuman takes a string made up of contiguous "0-9" characters and

--- a/parsers/number.go
+++ b/parsers/number.go
@@ -80,5 +80,5 @@ func (n *NumberGroup) DoIntoHuman(s string) string {
 
 // DoFromHuman ...
 func (n *NumberGroup) DoFromHuman(s string) string {
-	return ""
+	return strings.Replace(s, ",", "", -1)
 }

--- a/parsers/number_test.go
+++ b/parsers/number_test.go
@@ -82,3 +82,30 @@ func TestNumberGroupDoIntoHuman(t *testing.T) {
 		})
 	}
 }
+
+func TestNumberGroupDoFromHuman(t *testing.T) {
+	tests := []struct {
+		in  string
+		out string
+	}{
+		{"1,000", "1000"},
+		{"10,000", "10000"},
+		{"100,000", "100000"},
+		{"1,000,000", "1000000"},
+		{"10,000,000", "10000000"},
+		{"100,000,000", "100000000"},
+		{"1,000,000,000", "1000000000"},
+		{"10,000,000,000", "10000000000"},
+		{"100,000,000,000", "100000000000"},
+	}
+
+	numbergroup := NewNumberGroup()
+	for i, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got := numbergroup.DoFromHuman(tt.in)
+			if got != tt.out {
+				t.Errorf("Case %d: Given = `%s` ; want `%s` ; got `%s`", i, tt.in, tt.out, got)
+			}
+		})
+	}
+}

--- a/parsers/number_test.go
+++ b/parsers/number_test.go
@@ -31,6 +31,29 @@ func TestNumberGroupCanParseIntoHuman(t *testing.T) {
 	}
 }
 
+func TestNumberGroupCanParseFromHuman(t *testing.T) {
+	tests := []struct {
+		in  string
+		out bool
+	}{
+		{"999", false},
+		{"1000", false},
+		{"1,000", true},
+		{"1,00f", false},
+		{"1,000,000", true},
+	}
+
+	numbergroup := NewNumberGroup()
+	for i, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got := numbergroup.CanParseFromHuman(tt.in)
+			if got != tt.out {
+				t.Errorf("Case %d: Given = `%s` ; want `%t` ; got `%t`", i, tt.in, tt.out, got)
+			}
+		})
+	}
+}
+
 func TestNumberGroupDoIntoHuman(t *testing.T) {
 	tests := []struct {
 		in  string


### PR DESCRIPTION
Something to note here is the use of a slice of functions for conditions. I'm experimenting with an idea in that the conditions could become abstract using this pattern instead of the imperative if condition approach of the CanParseIntoHuman function... still chewing on it

fixes: #1 