### PR TITLE
NumberWord CanDoIntoHuman and DoIntoHuman

### DIFF
--- a/parsers/numword.go
+++ b/parsers/numword.go
@@ -18,28 +18,26 @@ import (
 // converts to word strings of the greatest power
 type NumberWord struct{}
 
-// NewNumberWord construcs a NumberWord struct
+// NewNumberWord constructs a NumberWord struct
 func NewNumberWord() *NumberWord {
 	return &NumberWord{}
 }
 
 // CanParseIntoHuman ...
+// is it 4 or more characters? (e.g. is it => 1000)
+// is it a (delimited[,. ]) number?
+// is it less than the max?
+//  67 places plus delimiters = 88 char
+// everything else is not a number
 func (n *NumberWord) CanParseIntoHuman(s string) bool {
-	// is it 4 or more characters? (e.g. is it => 1000)
 	if len(s) < 4 {
 		return false
 	}
 
-	// is it a (delimited[,. ]) number?
 	match, _ := regexp.MatchString(`^(([0-9]+)|([0-9]{1,3}[., ])+[0-9]{1,3})$`, s)
-	if match {
-		// is it less than the max?
-		//  300000 max places plus delimiters
-		if len(s) < 400000 {
+	if match && len(s) < 88 {
 			return true
-		}
-	}
-	// everything else is not a number
+    }
 	return false
 }
 
@@ -51,6 +49,9 @@ func (n *NumberWord) CanParseFromHuman(s string) bool {
 }
 
 // DoIntoHuman ...
+// Can accept delimited numbers
+// Uses NumberGroup to make an array
+// Rounds second group to nearest hundreds (i.e. 1 decimal place)
 func (n *NumberWord) DoIntoHuman(s string) string {
 	trans := map[int]struct {
 		name   string
@@ -61,20 +62,35 @@ func (n *NumberWord) DoIntoHuman(s string) string {
 		3: {"million", 6},
 		4: {"billion", 9},
 		5: {"trillion", 12},
+        6: {"quadrillion", 15},
+        7: {"quintillion", 18},
+        8: {"sextillion", 21},
+        9: {"septillion", 24},
+        10: {"octillion", 27},
+        11: {"nonillion", 30},
+        12: {"decillion", 33},
+        13: {"undecillion", 36},
+        14: {"duodecillion", 39},
+        15: {"tredecillion", 42},
+        16: {"quattuordecillion", 45},
+        17: {"quindecillion", 48},
+        18: {"sexdecillion", 51},
+        19: {"septendecillion", 54},
+        20: {"octodecillion", 57},
+        21: {"novemdecillion", 60},
+        22: {"vigintillion", 63},
 	}
 
 	// Strip delimiters
 	r := regexp.MustCompile("[^0-9]")
 	s = r.ReplaceAllString(s, "")
 
-	// Use NumberGroup to make an array
 	numgroup := NewNumberGroup()
 	numbers := strings.Split(numgroup.DoIntoHuman(s), ",")
 
 	var out strings.Builder
 	out.WriteString(numbers[0])
 
-	// Round second group to nearest hundreds (i.e. 1 decimal place)
 	x, _ := strconv.ParseFloat(numbers[1], 64)
 	decimal := int(math.Round(x / 100.0))
 

--- a/parsers/numword.go
+++ b/parsers/numword.go
@@ -6,12 +6,17 @@
 package parsers
 
 import (
-  "regexp"
+  //"regexp"
 )
 
 // NumberWord handles strings made of contiguous "0-9" characters
 // converts to word strings of the greatest power
 type NumberWord struct{}
+
+// NewNumberWord construcs a NumberWord struct
+func NewNumberWord() *NumberWord {
+  return &NumberWord{}
+}
 
 // CanParseIntoHuman ...
 func (n *NumberWord) CanParseIntoHuman(s string) bool {

--- a/parsers/numword.go
+++ b/parsers/numword.go
@@ -6,7 +6,7 @@
 package parsers
 
 import (
-  //"regexp"
+  "regexp"
 )
 
 // NumberWord handles strings made of contiguous "0-9" characters
@@ -21,11 +21,20 @@ func NewNumberWord() *NumberWord {
 // CanParseIntoHuman ...
 func (n *NumberWord) CanParseIntoHuman(s string) bool {
   // is it 4 or more characters? (e.g. is it => 1000)
-  // is it a number? /[0-9]*/
-  // is it a delimited number? /(0-9{1,3}(?:[,.; ])){1,}/
-  // is it less than the max? 
-    // - Less than chars (300000)
-    // - Less than 100 ^ 303
+  if len(s) < 4 {
+    return false
+  }
+
+  // is it a (delimited[,. ]) number?
+  match, _ := regexp.MatchString(`^(([0-9]+)|([0-9]{1,3}[., ])+[0-9]{1,3})$`, s)
+  if match {
+    // is it less than the max? 
+      //  300000 max places plus delimiters
+    if len(s) < 400000 {
+      return true
+    }
+  }
+  // everything else is not a number
   return false
 }
 

--- a/parsers/numword.go
+++ b/parsers/numword.go
@@ -1,0 +1,63 @@
+// Given a number in string form
+// Return the number in word form of the greatest power (e.g. 300,100,000,000 => 300.1 Billion)
+// Lower limit > Thousands (e.g. xxx,000) # Numbers below this are in hundreds and can be expressed numerically
+// Upper limit > Centillion (10^303) ref: https://en.wikipedia.org/wiki/Names_of_large_numbers#Standard_dictionary_numbers
+
+package parsers
+
+import (
+  "regexp"
+)
+
+// NumberWord handles strings made of contiguous "0-9" characters
+// converts to word strings of the greatest power
+type NumberWord struct{}
+
+// isNumber takes a string and verifies that it only contains the characters [0-9]
+func (n *NumberWord) isNumber(s string) bool {
+  return false
+}
+
+// isDelimitedNumber takes a string and checks it for a 3 place delimited form
+// e.g. '1,000,000', '1.000.000', '1 000 000'
+// using common delimiters
+func (n *NumberWord) isDelimitedNumber(s string) bool {
+  return false
+}
+
+// CanParseIntoHuman ...
+func (n *NumberWord) CanParseIntoHuman(s string) bool {
+  // is it 4 or more characters? (e.g. is it => 1000)
+  // is it a number? /[0-9]*/
+  // is it a delimited number? /(0-9{1,3}(?:[,.; ])){1,}/
+  // is it less than the max? 
+    // - Less than chars (300000)
+    // - Less than 100 ^ 303
+  return false
+}
+
+// CanParseFromHuman ...
+func (n *NumberWord) CanParseFromHuman(s string) bool {
+  // is it a digit word combo? (e.g. 48 billion) /\d+ [a-zA-Z]+)
+  // is the word in the enumerators?
+  return false
+}
+
+// DoIntoHuman ...
+func (n *NumberWord) DoIntoHuman(s string) string {
+  // Create a NumberGroup from string
+  // Split the NumberGroup string into an array ng[]
+  // Compare the len of ng[] with numwords enum index
+  // Round ng[1] to hundreds place (e.g. 155 => 200) = decimals
+  // Return ng[0]+ "." + decimal  + " " + numwords[len(ng)] 
+  return "100.0 FOOillion"
+}
+
+// DoFromHuman ...
+// Only works with highest power (e.g. 100.3 Billion, not 100,300 Million)
+func (n *NumberWord) DoFromHuman(s string) string {
+  // Split numbers from word
+  // Get powers from enumerator map
+  // Return ( numbers * 10^foo )
+  return "100"
+}

--- a/parsers/numword.go
+++ b/parsers/numword.go
@@ -6,7 +6,10 @@
 package parsers
 
 import (
+  "math"
   "regexp"
+  "strings"
+  "strconv"
 )
 
 // NumberWord handles strings made of contiguous "0-9" characters
@@ -47,12 +50,38 @@ func (n *NumberWord) CanParseFromHuman(s string) bool {
 
 // DoIntoHuman ...
 func (n *NumberWord) DoIntoHuman(s string) string {
-  // Create a NumberGroup from string
-  // Split the NumberGroup string into an array ng[]
-  // Compare the len of ng[] with numwords translation index
-  // Round ng[1] to hundreds place (e.g. 155 => 200) = decimals
-  // Return ng[0]+ "." + decimal  + " " + numwords[len(ng)] 
-  return "100.0 FOOillion"
+	trans := map[int]struct{
+		name string
+		powers int
+	}{
+    1: {"hundred", 2}, // not used
+    2: {"thousand", 3},
+    3: {"million", 6},
+    4: {"billion", 9},
+    5: {"trillion", 12},
+	}
+
+  // Strip delimiters
+  r, _ := regexp.Compile("[^0-9]")
+  s = r.ReplaceAllString(s, "")
+
+  // Use NumberGroup to make an array
+  numgroup := NewNumberGroup()
+  numbers := strings.Split(numgroup.DoIntoHuman(s), ",")
+
+  var out strings.Builder
+  out.WriteString( numbers[0] )
+
+  // Round second group to nearest hundreds (i.e. 1 decimal place)
+  x, _ := strconv.ParseFloat(numbers[1], 64)
+  decimal := int(math.Round( x / 100.0 ))
+
+  if decimal > 0 {
+    out.WriteString( "." + strconv.Itoa( decimal ))
+  }
+  out.WriteString( " " + trans[ len(numbers) ].name )
+
+  return out.String()
 }
 
 // DoFromHuman ...

--- a/parsers/numword.go
+++ b/parsers/numword.go
@@ -6,89 +6,91 @@
 package parsers
 
 import (
-  "math"
-  "regexp"
-  "strings"
-  "strconv"
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
 )
 
 // NumberWord handles strings made of contiguous "0-9" characters
+// strings delimited by [,. ] are accepted
+// strings are assumed to have no decimal places
 // converts to word strings of the greatest power
 type NumberWord struct{}
 
 // NewNumberWord construcs a NumberWord struct
 func NewNumberWord() *NumberWord {
-  return &NumberWord{}
+	return &NumberWord{}
 }
 
 // CanParseIntoHuman ...
 func (n *NumberWord) CanParseIntoHuman(s string) bool {
-  // is it 4 or more characters? (e.g. is it => 1000)
-  if len(s) < 4 {
-    return false
-  }
+	// is it 4 or more characters? (e.g. is it => 1000)
+	if len(s) < 4 {
+		return false
+	}
 
-  // is it a (delimited[,. ]) number?
-  match, _ := regexp.MatchString(`^(([0-9]+)|([0-9]{1,3}[., ])+[0-9]{1,3})$`, s)
-  if match {
-    // is it less than the max? 
-      //  300000 max places plus delimiters
-    if len(s) < 400000 {
-      return true
-    }
-  }
-  // everything else is not a number
-  return false
+	// is it a (delimited[,. ]) number?
+	match, _ := regexp.MatchString(`^(([0-9]+)|([0-9]{1,3}[., ])+[0-9]{1,3})$`, s)
+	if match {
+		// is it less than the max?
+		//  300000 max places plus delimiters
+		if len(s) < 400000 {
+			return true
+		}
+	}
+	// everything else is not a number
+	return false
 }
 
 // CanParseFromHuman ...
 func (n *NumberWord) CanParseFromHuman(s string) bool {
-  // is it a digit word combo? (e.g. 48 billion) /\d+ [a-zA-Z]+)
-  // is the word in the translation map?
-  return false
+	// is it a digit word combo? (e.g. 48 billion) /\d+ [a-zA-Z]+)
+	// is the word in the translation map?
+	return false
 }
 
 // DoIntoHuman ...
 func (n *NumberWord) DoIntoHuman(s string) string {
-	trans := map[int]struct{
-		name string
+	trans := map[int]struct {
+		name   string
 		powers int
 	}{
-    1: {"hundred", 2}, // not used
-    2: {"thousand", 3},
-    3: {"million", 6},
-    4: {"billion", 9},
-    5: {"trillion", 12},
+		1: {"hundred", 2}, // not used
+		2: {"thousand", 3},
+		3: {"million", 6},
+		4: {"billion", 9},
+		5: {"trillion", 12},
 	}
 
-  // Strip delimiters
-  r, _ := regexp.Compile("[^0-9]")
-  s = r.ReplaceAllString(s, "")
+	// Strip delimiters
+	r := regexp.MustCompile("[^0-9]")
+	s = r.ReplaceAllString(s, "")
 
-  // Use NumberGroup to make an array
-  numgroup := NewNumberGroup()
-  numbers := strings.Split(numgroup.DoIntoHuman(s), ",")
+	// Use NumberGroup to make an array
+	numgroup := NewNumberGroup()
+	numbers := strings.Split(numgroup.DoIntoHuman(s), ",")
 
-  var out strings.Builder
-  out.WriteString( numbers[0] )
+	var out strings.Builder
+	out.WriteString(numbers[0])
 
-  // Round second group to nearest hundreds (i.e. 1 decimal place)
-  x, _ := strconv.ParseFloat(numbers[1], 64)
-  decimal := int(math.Round( x / 100.0 ))
+	// Round second group to nearest hundreds (i.e. 1 decimal place)
+	x, _ := strconv.ParseFloat(numbers[1], 64)
+	decimal := int(math.Round(x / 100.0))
 
-  if decimal > 0 {
-    out.WriteString( "." + strconv.Itoa( decimal ))
-  }
-  out.WriteString( " " + trans[ len(numbers) ].name )
+	if decimal > 0 {
+		out.WriteString("." + strconv.Itoa(decimal))
+	}
+	out.WriteString(" " + trans[len(numbers)].name)
 
-  return out.String()
+	return out.String()
 }
 
 // DoFromHuman ...
 // Only works with highest power (e.g. 100.3 Billion, not 100,300 Million)
 func (n *NumberWord) DoFromHuman(s string) string {
-  // Split numbers from word
-  // Get powers from translation map
-  // Return ( numbers * 10^foo )
-  return "100"
+	// Split numbers from word
+	// Get powers from translation map
+	// Return ( numbers * 10^foo )
+	return "100"
 }

--- a/parsers/numword.go
+++ b/parsers/numword.go
@@ -1,7 +1,8 @@
 // Given a number in string form
 // Return the number in word form of the greatest power (e.g. 300,100,000,000 => 300.1 Billion)
 // Lower limit > Thousands (e.g. xxx,000) # Numbers below this are in hundreds and can be expressed numerically
-// Upper limit > Centillion (10^303) ref: https://en.wikipedia.org/wiki/Names_of_large_numbers#Standard_dictionary_numbers
+// Upper limit > Vigintillion (10^63) 
+// ref: https://en.wikipedia.org/wiki/Names_of_large_numbers#Standard_dictionary_numbers
 
 package parsers
 

--- a/parsers/numword.go
+++ b/parsers/numword.go
@@ -13,18 +13,6 @@ import (
 // converts to word strings of the greatest power
 type NumberWord struct{}
 
-// isNumber takes a string and verifies that it only contains the characters [0-9]
-func (n *NumberWord) isNumber(s string) bool {
-  return false
-}
-
-// isDelimitedNumber takes a string and checks it for a 3 place delimited form
-// e.g. '1,000,000', '1.000.000', '1 000 000'
-// using common delimiters
-func (n *NumberWord) isDelimitedNumber(s string) bool {
-  return false
-}
-
 // CanParseIntoHuman ...
 func (n *NumberWord) CanParseIntoHuman(s string) bool {
   // is it 4 or more characters? (e.g. is it => 1000)
@@ -39,7 +27,7 @@ func (n *NumberWord) CanParseIntoHuman(s string) bool {
 // CanParseFromHuman ...
 func (n *NumberWord) CanParseFromHuman(s string) bool {
   // is it a digit word combo? (e.g. 48 billion) /\d+ [a-zA-Z]+)
-  // is the word in the enumerators?
+  // is the word in the translation map?
   return false
 }
 
@@ -47,7 +35,7 @@ func (n *NumberWord) CanParseFromHuman(s string) bool {
 func (n *NumberWord) DoIntoHuman(s string) string {
   // Create a NumberGroup from string
   // Split the NumberGroup string into an array ng[]
-  // Compare the len of ng[] with numwords enum index
+  // Compare the len of ng[] with numwords translation index
   // Round ng[1] to hundreds place (e.g. 155 => 200) = decimals
   // Return ng[0]+ "." + decimal  + " " + numwords[len(ng)] 
   return "100.0 FOOillion"
@@ -57,7 +45,7 @@ func (n *NumberWord) DoIntoHuman(s string) string {
 // Only works with highest power (e.g. 100.3 Billion, not 100,300 Million)
 func (n *NumberWord) DoFromHuman(s string) string {
   // Split numbers from word
-  // Get powers from enumerator map
+  // Get powers from translation map
   // Return ( numbers * 10^foo )
   return "100"
 }

--- a/parsers/numword_test.go
+++ b/parsers/numword_test.go
@@ -1,0 +1,33 @@
+package parsers
+
+import (
+	"testing"
+)
+
+func TestNumberWordCanParseIntoHuman(t *testing.T) {
+	tests := []struct {
+		in  string
+		out bool
+	}{
+		// Only numbergroups
+		{"aba", false},
+		{"12af", false},
+		// Lower bounds
+		{"999", false},
+		// Anything else should be parsable
+		{"1000", true},
+		{"100000000000", true},
+		{"1338054622987", true},
+	}
+
+  numword := NewNumberWord()
+  for i, tt := range tests {
+    t.Run(tt.in, func(t *testing.T) {
+      got := numword.CanParseIntoHuman(tt.in)
+      if got != tt.out {
+        t.Errorf("Case %d: Given = `%s` ; want `%t` ; got `%t`", i, tt.in, tt.out, got)
+      }
+    })
+  }
+}
+

--- a/parsers/numword_test.go
+++ b/parsers/numword_test.go
@@ -13,9 +13,11 @@ func TestNumberWordCanParseIntoHuman(t *testing.T) {
 		{"aba", false},
 		{"12af", false},
 		{"123,afb,$$@", false},
-		// Lower bounds
+		// Lower/Upper Bounds
 		{"999", false},
-		// Upper bound is 400000 characters...
+        {"1000", true},
+        {"100,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000", true},
+        {"1,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000", false},
 		// Delimiters
 		{"1,000,000", true},
 		{"1.000.000", true},
@@ -57,6 +59,7 @@ func TestNumberWordDoIntoHuman(t *testing.T) {
 		{"1000000", "1 million"},
 		{"1000000000", "1 billion"},
 		{"1000000000000", "1 trillion"},
+        {"1,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000,000", "1 vigintillion"},
 	}
 
 	numword := NewNumberWord()

--- a/parsers/numword_test.go
+++ b/parsers/numword_test.go
@@ -12,60 +12,60 @@ func TestNumberWordCanParseIntoHuman(t *testing.T) {
 		// Only numbers
 		{"aba", false},
 		{"12af", false},
-    {"123,afb,$$@", false},
+		{"123,afb,$$@", false},
 		// Lower bounds
 		{"999", false},
-    // Upper bound is 400000 characters...
-    // Delimiters
-    {"1,000,000", true},
-    {"1.000.000", true},
-    {"1 000 000", true},
-    {"1a000a000", false},
+		// Upper bound is 400000 characters...
+		// Delimiters
+		{"1,000,000", true},
+		{"1.000.000", true},
+		{"1 000 000", true},
+		{"1a000a000", false},
 		// Anything else should be parsable
 		{"1000", true},
 		{"100000000000", true},
 		{"1338054622987", true},
 	}
 
-  numword := NewNumberWord()
-  for i, tt := range tests {
-    t.Run(tt.in, func(t *testing.T) {
-      got := numword.CanParseIntoHuman(tt.in)
-      if got != tt.out {
-        t.Errorf("Case %d: Given = `%s` ; want `%t` ; got `%t`", i, tt.in, tt.out, got)
-      }
-    })
-  }
+	numword := NewNumberWord()
+	for i, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got := numword.CanParseIntoHuman(tt.in)
+			if got != tt.out {
+				t.Errorf("Case %d: Given = `%s` ; want `%t` ; got `%t`", i, tt.in, tt.out, got)
+			}
+		})
+	}
 }
 
 func TestNumberWordDoIntoHuman(t *testing.T) {
-  tests := []struct {
-    in string
-    out string
-  }{
-    // Each position
+	tests := []struct {
+		in  string
+		out string
+	}{
+		// Each position
 		{"1000", "1 thousand"},
 		{"10000", "10 thousand"},
 		{"100000", "100 thousand"},
-    // First decimal
+		// First decimal
 		{"12345678", "12.3 million"},
-    // Delimiters
-    {"1,000,000", "1 million"},
-    {"1.000.000", "1 million"},
-    {"1 000 000", "1 million"},
-    // All the names
+		// Delimiters
+		{"1,000,000", "1 million"},
+		{"1.000.000", "1 million"},
+		{"1 000 000", "1 million"},
+		// All the names
 		{"1000000", "1 million"},
 		{"1000000000", "1 billion"},
 		{"1000000000000", "1 trillion"},
-  }
+	}
 
-  numword := NewNumberWord()
-  for i, tt := range tests {
-    t.Run(tt.in, func(t *testing.T) {
-      got := numword.DoIntoHuman(tt.in)
-      if got != tt.out {
-        t.Errorf("Case %d: Given = `%s` ; want `%s` ; got `%s`", i, tt.in, tt.out, got)
-      }
-    })
-  }
+	numword := NewNumberWord()
+	for i, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got := numword.DoIntoHuman(tt.in)
+			if got != tt.out {
+				t.Errorf("Case %d: Given = `%s` ; want `%s` ; got `%s`", i, tt.in, tt.out, got)
+			}
+		})
+	}
 }

--- a/parsers/numword_test.go
+++ b/parsers/numword_test.go
@@ -14,6 +14,11 @@ func TestNumberWordCanParseIntoHuman(t *testing.T) {
 		{"12af", false},
 		// Lower bounds
 		{"999", false},
+    // Delimited numbers
+    {"1,000,000", true},
+    {"1.000.000", true},
+    {"1 000 000", true},
+    {"1a000a000", false},
 		// Anything else should be parsable
 		{"1000", true},
 		{"100000000000", true},

--- a/parsers/numword_test.go
+++ b/parsers/numword_test.go
@@ -9,12 +9,14 @@ func TestNumberWordCanParseIntoHuman(t *testing.T) {
 		in  string
 		out bool
 	}{
-		// Only numbergroups
+		// Only numbers
 		{"aba", false},
 		{"12af", false},
+    {"123,afb,$$@", false},
 		// Lower bounds
 		{"999", false},
-    // Delimited numbers
+    // Upper bound is 400000 characters...
+    // Delimiters
     {"1,000,000", true},
     {"1.000.000", true},
     {"1 000 000", true},
@@ -36,3 +38,34 @@ func TestNumberWordCanParseIntoHuman(t *testing.T) {
   }
 }
 
+func TestNumberWordDoIntoHuman(t *testing.T) {
+  tests := []struct {
+    in string
+    out string
+  }{
+    // Each position
+		{"1000", "1 thousand"},
+		{"10000", "10 thousand"},
+		{"100000", "100 thousand"},
+    // First decimal
+		{"12345678", "12.3 million"},
+    // Delimiters
+    {"1,000,000", "1 million"},
+    {"1.000.000", "1 million"},
+    {"1 000 000", "1 million"},
+    // All the names
+		{"1000000", "1 million"},
+		{"1000000000", "1 billion"},
+		{"1000000000000", "1 trillion"},
+  }
+
+  numword := NewNumberWord()
+  for i, tt := range tests {
+    t.Run(tt.in, func(t *testing.T) {
+      got := numword.DoIntoHuman(tt.in)
+      if got != tt.out {
+        t.Errorf("Case %d: Given = `%s` ; want `%s` ; got `%s`", i, tt.in, tt.out, got)
+      }
+    })
+  }
+}


### PR DESCRIPTION
Adding the initial tests and code for NumberWord.CanDoIntoHuman() and DoIntoHuman().

A PR may be premature at this point, but I figured its a good place to ask these questions.

~~I'm not sure how to write an efficient test for the upper bound (400000 characters).  I thought of generating a string with repeating 0's but that seems excessive and I'm not sure how to do it inline like that anyways.  Any advice?~~

The trans table is going to need to be much bigger (~25 items) and shared with the DoFromHuman() method later.  Where should that be moved to?  ~~Is it possible to load that in from a separate "data" file that is compiled into the binary or is that amount of "data" not a concern?~~

The way NumberGroup is written it is assumed that the user is verifying `CanDoInto()` before `DoInto()`.  Is that an assumed convention in Golang/human, something that should be mentioned explicitly in code, or should DoInto() ensure it CanDoInto()?

Anything I can improve on here?  Should I convert my CanDoInto logic into the list of funcs that you used?