### PR TITLE
remove early abstraction

### DIFF
--- a/parsers/number.go
+++ b/parsers/number.go
@@ -24,30 +24,25 @@ func (n *NumberGroup) CanParseIntoHuman(s string) bool {
 	return !match
 }
 
-// CanParseFromHuman ...
+// CanParseFromHuman determines if input is within bounds
+// in that the input:
+// 	Should at least be the number 1 thousand
+// 	Can't have letters in it
+// 	Needs to have a comma in it
 func (n *NumberGroup) CanParseFromHuman(s string) bool {
 
-	conds := []func(string) bool{
-		// Should at least be the number 1 thousand
-		func(s string) bool {
-			return len(s) >= 4
-		},
-		// Can't have letters in it
-		func(s string) bool {
-			match, _ := regexp.MatchString(`[a-z]+`, s)
-			return !match
-		},
-		// Needs to have a comma in it
-		func(s string) bool {
-			return strings.Contains(s, ",")
-		},
+	if len(s) <= 4 {
+		return false
 	}
 
-	for _, c := range conds {
-		if c(s) == false {
-			return false
-		}
+	if match, _ := regexp.MatchString(`[a-z]+`, s); match {
+		return false
 	}
+
+	if !strings.Contains(s, ",") {
+		return false
+	}
+
 	return true
 }
 


### PR DESCRIPTION
Idea was to see if we _could/should_ abstract these conditions, feel like the code is easier to understand read without the abstraction though.

If and when we need something more abstract we'll cross that bridge when we get to it.


```
go test
PASS
ok      github.com/andres-lowrie/human/parsers  0.086s
```