### PR TITLE
CanParseFromHuman() error handling

### DIFF
--- a/parsers/number.go
+++ b/parsers/number.go
@@ -21,15 +21,19 @@ func NewNumberGroup() *NumberGroup {
 // Contains only digits
 // Is >= 1000
 func (n *NumberGroup) CanParseIntoHuman(s string) (bool, error) {
-	if isMachineNumber(s) {
-		if len(s) < 4 {
-			return false, ErrTooSmall
-		}
+	if isMachineNumber(s) && len(s) >= 4 {
 		return true, nil
 	}
 
-	return false, ErrNotANumber
+	// Error cases
+	var err error
 
+	if isMachineNumber(s) && len(s) < 4 {
+		err = ErrTooSmall
+	} else {
+		err = ErrNotANumber
+	}
+	return false, err
 }
 
 // CanParseFromHuman determines if input is within bounds
@@ -38,22 +42,26 @@ func (n *NumberGroup) CanParseIntoHuman(s string) (bool, error) {
 // 	Can't have letters in it
 // 	Needs to have a comma in it
 func (n *NumberGroup) CanParseFromHuman(s string) (bool, error) {
+	if isDelimitedNumber(s) && len(s) >= 4 {
+		return true, nil
+	}
+
+	// Error cases
+	var err error
 
 	if isMachineNumber(s) && len(s) < 4 {
-		return false, ErrTooSmall
+		err = ErrTooSmall
 	} else if isMachineNumber(s) {
-		return false, ErrNotHumanGroup
-	} else if isDelimitedNumber(s) {
-		return true, nil
+		err = ErrNotHumanGroup
 	} else {
-		return false, ErrNotANumber
+		err = ErrNotANumber
 	}
+	return false, err
 }
 
 // DoIntoHuman takes a string made up of contiguous "0-9" characters and
 // returns number groupings
 func (n *NumberGroup) DoIntoHuman(s string) string {
-
 	// Figure out where to place commas
 	var buf strings.Builder
 	bufLen := len(s) - 1

--- a/parsers/number_test.go
+++ b/parsers/number_test.go
@@ -40,20 +40,24 @@ func TestNumberGroupCanParseFromHuman(t *testing.T) {
 	tests := []struct {
 		in  string
 		out bool
+		err error
 	}{
-		{"999", false},
-		{"1000", false},
-		{"1,000", true},
-		{"1,00f", false},
-		{"1,000,000", true},
+		{"999", false, ErrTooSmall},
+		{"1000", false, ErrNotHumanGroup},
+		{"1,000", true, nil},
+		{"1,00f", false, ErrNotANumber},
+		{"1,000,000", true, nil},
 	}
 
 	numbergroup := NewNumberGroup()
 	for i, tt := range tests {
 		t.Run(tt.in, func(t *testing.T) {
-			got := numbergroup.CanParseFromHuman(tt.in)
+			got, err := numbergroup.CanParseFromHuman(tt.in)
 			if got != tt.out {
 				t.Errorf("Case %d: Given = `%s` ; want `%t` ; got `%t`", i, tt.in, tt.out, got)
+			}
+			if err != tt.err {
+				t.Errorf("Case %d: Given = `%s` ; want `%t` ; got `%t`", i, tt.in, tt.err, err)
 			}
 		})
 	}

--- a/parsers/numword.go
+++ b/parsers/numword.go
@@ -69,22 +69,29 @@ func NewNumberWord() *NumberWord {
 //  67 places plus delimiters = 88 char
 // everything else is not a number
 func (n *NumberWord) CanParseIntoHuman(s string) (bool, error) {
-	if isDelimitedNumber(s) || isMachineNumber(s) {
-		if len(s) >= 88 {
-			return false, ErrTooLarge
-		} else if len(s) < 4 {
-			return false, ErrTooSmall
-		} else {
-			return true, nil
-		}
+	if (len(s) >= 4) && (len(s) <= 88) &&
+		(isMachineNumber(s) || isDelimitedNumber(s)) {
+		return true, nil
 	}
-	return false, ErrNotANumber
+
+	// Error Cases
+	var err error
+	if !(isDelimitedNumber(s) || isMachineNumber(s)) {
+		err = ErrNotANumber
+	} else if len(s) >= 88 {
+		err = ErrTooLarge
+	} else if len(s) < 4 {
+		err = ErrTooSmall
+	}
+
+	return false, err
 }
 
 // CanParseFromHuman ...
 // is it a digit word combo? ( <number>[.tenths] <word> )
 // is the word in the trans table? (case insensitive)
 func (n *NumberWord) CanParseFromHuman(s string) (bool, error) {
+	//
 	match, _ := regexp.MatchString(`^[0-9]+([.][0-9])? [a-zA-Z]+$`, s)
 	if match {
 		_, word := splitHumanNumberWord(s)
@@ -153,9 +160,13 @@ func (n *NumberWord) DoFromHuman(s string) string {
 
 // splitHumanNumberWord takes a digit word pair and returns the individual components
 // <digit>[.<tenths>] <word>
+// Output is lower cased
 func splitHumanNumberWord(s string) (string, string) {
 	a := strings.Split(s, " ")
+	// is len(a) == 2?
 	num, word := a[0], a[1]
+	// isMachineNumber(num)?
+	// is word only letters?
 	word = strings.ToLower(word)
 	return num, word
 }

--- a/parsers/numword.go
+++ b/parsers/numword.go
@@ -7,12 +7,16 @@
 package parsers
 
 import (
+	"errors"
 	"fmt"
 	"math"
 	"regexp"
 	"strconv"
 	"strings"
 )
+
+// Method specific errors
+var ErrNotADigitWordCombo error = errors.New("Not a <digit> <word> combo")
 
 // NumberWord handles strings made of contiguous "0-9" characters
 // strings delimited by [,. ] are accepted
@@ -65,8 +69,7 @@ func NewNumberWord() *NumberWord {
 //  67 places plus delimiters = 88 char
 // everything else is not a number
 func (n *NumberWord) CanParseIntoHuman(s string) (bool, error) {
-	match, _ := regexp.MatchString(`^(([0-9]+)|([0-9]{1,3}[., ])+[0-9]{1,3})$`, s)
-	if match {
+	if isDelimitedNumber(s) || isMachineNumber(s) {
 		if len(s) >= 88 {
 			return false, ErrTooLarge
 		} else if len(s) < 4 {
@@ -81,19 +84,19 @@ func (n *NumberWord) CanParseIntoHuman(s string) (bool, error) {
 // CanParseFromHuman ...
 // is it a digit word combo? ( <number>[.tenths] <word> )
 // is the word in the trans table? (case insensitive)
-func (n *NumberWord) CanParseFromHuman(s string) bool {
+func (n *NumberWord) CanParseFromHuman(s string) (bool, error) {
 	match, _ := regexp.MatchString(`^[0-9]+([.][0-9])? [a-zA-Z]+$`, s)
 	if match {
 		_, word := splitHumanNumberWord(s)
 
 		for _, v := range n.trans {
 			if v.name == word {
-				return true
+				return true, nil
 			}
 		}
 	}
 
-	return false
+	return false, ErrNotADigitWordCombo
 }
 
 // DoIntoHuman ...

--- a/parsers/numword_test.go
+++ b/parsers/numword_test.go
@@ -48,38 +48,42 @@ func TestNumberWordCanParseFromHumans(t *testing.T) {
 	tests := []struct {
 		in  string
 		out bool
+		err error
 	}{
 		// Must be <digits> <word>
-		{"1", false},
-		{"million", false},
-		{"one million", false},
-		{"1 million!", false},
-		// <word> must be in the trans table
-		{"1 foo", false},
-		// none of this garbage
-		{"100,000 million", false},
-		{"100.000 million", false},
-		{"100 000 million", false},
-		// These names are excluded by design
-		{"1 centillion", false},
-		{"1 googol", false},
-		{"1 googolplex", false},
+		{"1", false, ErrNotADigitWordCombo},
+		//{"million", false, ErrNotADigitWordCombo},
+		//{"one million", false, ErrNotADigitWordCombo},
+		//{"1 million!", false, ErrNotADigitWordCombo},
+		//// <word> must be in the trans table
+		//{"1 foo", false, ErrNotADigitWordCombo},
+		//// none of this garbage
+		//{"100,000 million", false, ErrNotADigitWordCombo},
+		//{"100.000 million", false, ErrNotADigitWordCombo},
+		//{"100 000 million", false, ErrNotADigitWordCombo},
+		//// These names are excluded by design
+		//{"1 centillion", false, ErrNotADigitWordCombo},
+		//{"1 googol", false, ErrNotADigitWordCombo},
+		//{"1 googolplex", false, ErrNotADigitWordCombo},
 
-		// Tenths, Ones, Tens, Hundreds
-		{"1 million", true},
-		{"10 million", true},
-		{"100 million", true},
-		{"1.3 million", true},
-		// case insensitive
-		{"1 MiLlIon", true},
+		//// Tenths, Ones, Tens, Hundreds
+		//{"1 million", true, nil},
+		//{"10 million", true, nil},
+		//{"100 million", true, nil},
+		//{"1.3 million", true, nil},
+		//// case insensitive
+		//{"1 MiLlIon", true, nil},
 	}
 
 	numword := NewNumberWord()
 	for i, tt := range tests {
 		t.Run(tt.in, func(t *testing.T) {
-			got := numword.CanParseFromHuman(tt.in)
+			got, err := numword.CanParseFromHuman(tt.in)
 			if got != tt.out {
 				t.Errorf("Case %d: Given = `%s` ; want `%t` ; got `%t`", i, tt.in, tt.out, got)
+			}
+			if err != tt.err {
+				t.Errorf("Case %d: Given = `%s` ; want `%t` ; got `%t`", i, tt.in, tt.err, err)
 			}
 		})
 	}

--- a/parsers/numword_test.go
+++ b/parsers/numword_test.go
@@ -52,27 +52,27 @@ func TestNumberWordCanParseFromHumans(t *testing.T) {
 	}{
 		// Must be <digits> <word>
 		{"1", false, ErrNotADigitWordCombo},
-		//{"million", false, ErrNotADigitWordCombo},
-		//{"one million", false, ErrNotADigitWordCombo},
-		//{"1 million!", false, ErrNotADigitWordCombo},
-		//// <word> must be in the trans table
-		//{"1 foo", false, ErrNotADigitWordCombo},
-		//// none of this garbage
-		//{"100,000 million", false, ErrNotADigitWordCombo},
-		//{"100.000 million", false, ErrNotADigitWordCombo},
-		//{"100 000 million", false, ErrNotADigitWordCombo},
-		//// These names are excluded by design
-		//{"1 centillion", false, ErrNotADigitWordCombo},
-		//{"1 googol", false, ErrNotADigitWordCombo},
-		//{"1 googolplex", false, ErrNotADigitWordCombo},
+		{"million", false, ErrNotADigitWordCombo},
+		{"one million", false, ErrNotADigitWordCombo},
+		{"1 million!", false, ErrNotADigitWordCombo},
+		// <word> must be in the trans table
+		{"1 foo", false, ErrNotADigitWordCombo},
+		// none of this garbage
+		{"100,000 million", false, ErrNotADigitWordCombo},
+		{"100.000 million", false, ErrNotADigitWordCombo},
+		{"100 000 million", false, ErrNotADigitWordCombo},
+		// These names are excluded by design
+		{"1 centillion", false, ErrNotADigitWordCombo},
+		{"1 googol", false, ErrNotADigitWordCombo},
+		{"1 googolplex", false, ErrNotADigitWordCombo},
 
-		//// Tenths, Ones, Tens, Hundreds
-		//{"1 million", true, nil},
-		//{"10 million", true, nil},
-		//{"100 million", true, nil},
-		//{"1.3 million", true, nil},
-		//// case insensitive
-		//{"1 MiLlIon", true, nil},
+		// Tenths, Ones, Tens, Hundreds
+		{"1 million", true, nil},
+		{"10 million", true, nil},
+		{"100 million", true, nil},
+		{"1.3 million", true, nil},
+		// case insensitive
+		{"1 MiLlIon", true, nil},
 	}
 
 	numword := NewNumberWord()

--- a/parsers/parsers.go
+++ b/parsers/parsers.go
@@ -2,15 +2,24 @@ package parsers
 
 import (
 	"errors"
+	"regexp"
 )
 
 // Parser is the contract that the main command line application will use
 type Parser interface {
 	CanParseIntoHuman(string) (bool error)
-	CanParseFromHuman(string) bool
+	CanParseFromHuman(string) (bool error)
 	DoIntoHuman(string) string
 	DoFromHuman(string) string
 }
+
+// General purpose errors
+var ErrNotANumber error = errors.New("Not a Number")
+var ErrTooLarge error = errors.New("Too Beaucoup")
+var ErrTooSmall error = errors.New("Number too small")
+
+// Catch all error
+var ErrUnparsable error = errors.New("Unparsable")
 
 // Empty can be used to as a placeholder for when an
 // interface is needed
@@ -24,8 +33,8 @@ func (e *Empty) CanParseIntoHuman(string) (t bool, err error) {
 	return true, nil
 }
 
-func (e *Empty) CanParseFromHuman(string) bool {
-	return true
+func (e *Empty) CanParseFromHuman(string) (t bool, err error) {
+	return true, nil
 }
 
 func (e *Empty) DoIntoHuman(string) string {
@@ -36,6 +45,35 @@ func (e *Empty) DoFromHuman(string) string {
 	return "Not Yet Implemented"
 }
 
-var ErrTooLarge error = errors.New("Too Beaucoup")
-var ErrTooSmall error = errors.New("Number too small")
-var ErrNotANumber error = errors.New("Not a Number")
+// IsMachineNumber validates that a number:
+// Contains only digits
+// The first digit must be 1-9 when >= 10
+func isMachineNumber(s string) bool {
+	match, _ := regexp.MatchString(`^[0-9]$|^[1-9][0-9]+$`, s)
+	if match {
+		return true
+	}
+	return false
+}
+
+// IsDelimitednumber validates that a number:
+// Contains only digits and` delimiters [., _]
+// The first digit must be 1-9 when >= 10
+// The first group can be 1-3 digits
+// Subsequent groups must be 3 digits
+func isDelimitedNumber(s string) bool {
+	// 0-999 are machine numbers
+	if len(s) < 4 {
+		if ok := isMachineNumber(s); ok {
+			return true
+		} else {
+			return false
+		}
+	}
+
+	match, _ := regexp.MatchString(`^[1-9][0-9]{0,2}([.,_ ][0-9]{3})+$`, s)
+	if match {
+		return true
+	}
+	return false
+}

--- a/parsers/parsers.go
+++ b/parsers/parsers.go
@@ -50,10 +50,7 @@ func (e *Empty) DoFromHuman(string) string {
 // The first digit must be 1-9 when >= 10
 func isMachineNumber(s string) bool {
 	match, _ := regexp.MatchString(`^[0-9]$|^[1-9][0-9]+$`, s)
-	if match {
-		return true
-	}
-	return false
+	return match
 }
 
 // IsDelimitednumber validates that a number:
@@ -61,6 +58,7 @@ func isMachineNumber(s string) bool {
 // The first digit must be 1-9 when >= 10
 // The first group can be 1-3 digits
 // Subsequent groups must be 3 digits
+// A number less than 1000 is considered a valid delimited number
 func isDelimitedNumber(s string) bool {
 	// 0-999 are machine numbers
 	if len(s) < 4 {
@@ -72,8 +70,5 @@ func isDelimitedNumber(s string) bool {
 	}
 
 	match, _ := regexp.MatchString(`^[1-9][0-9]{0,2}([.,_ ][0-9]{3})+$`, s)
-	if match {
-		return true
-	}
-	return false
+	return match
 }


### PR DESCRIPTION
There is additional work for the `CanParseIntoHuman()` methods included in the `feat/error-handling` branch.  The changes made to the Into functions are similar in nature to the changes noted in this PR [1]

Notable changes

- Addition of descriptive errors in the `CanParseIntoHuman` and `CanParseFromHuman` methods.  Some of these were added to `parsers.go` since they are shared (e.g. too large, too small, not a number), but some are in the specific implementation files themselves (e.g. not a comma delimited number, not a digit word group) - Should these all be consolidated in parsers.go?
- Testing of errors
- Updates to the regex for `NumberGroup` & `NumberWord` to more accurately reflect the desired functionalities.  This includes some consolidation to shared functions `isMachineNumber()` and `isDelimitedNumber()`
- Updates to the comments for `NumberGroup.CanParse*` methods

For context, my experience with interfaces is limited, so if the parsers.go file isn't the appropriate place for some of these changes please let me know.  I'm working on a basic assumption that anything needed by multiple implementations of the parser should go in parsers.go otherwise in the specific file (even though it gets picked up by the parser package in general).  I think we're getting into best practices here and I appreciate any guidance you can provide.

TODO for future `feat/error-handling`:
- DoInto/From methods should validate CanParse and raise errors and cmd should handle raised errors
? should the `is<foo>Number()` functions be tested independently of the CanParse? 

[1]https://github.com/andres-lowrie/human/compare/feat/error-handling
