### PR TITLE
invert direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 human
 ======
 
-Machine -> Human
-
-Human -> Machine
+Translate stuff from `Machine -> Human` and back again `Human -> Machine`
 
 ## TL;DR
 
@@ -31,4 +29,4 @@ human "run five minutes after midnight every day"
 > 5 0 * * *
 ```
 
-For full breakdown see [command](commands.md)
+For full breakdown see [commands](cmds/README.md)

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -1,4 +1,4 @@
-# cmd
+# Commands
 
 ## Calling Pattern
 

--- a/cmd/number.go
+++ b/cmd/number.go
@@ -26,12 +26,12 @@ func (n *Number) Run(direction string, input string, args CliArgs) string {
 		p = parsers.NewEmpty()
 	}
 
-	if ok, _ := p.CanParseFromHuman(input); direction == "from" && ok {
-		return p.DoFromHuman(input)
+	if ok, _ := p.CanParseFromMachine(input); direction == "from" && ok {
+		return p.DoFromMachine(input)
 	}
 
-	if ok, _ := p.CanParseIntoHuman(input); direction == "into" && ok {
-		return p.DoIntoHuman(input)
+	if ok, _ := p.CanParseIntoMachine(input); direction == "into" && ok {
+		return p.DoIntoMachine(input)
 	}
 
 	return ""

--- a/main.go
+++ b/main.go
@@ -22,12 +22,12 @@ func main() {
 	handlers := map[string]cmd.Command{"number": cmd.NewNumber()}
 
 	// Figure out direction and which format
-	// we'll default to the `--into` direction since it might be the most common
-	// usecase i.e. we want to go "into" human format
+	// we'll default to the `--from` direction since it might be the most common
+	// usecase i.e. we want to go "from" machine into human format
 	input := args.Positionals[0]
-	direction := "into"
+	direction := "from"
 	format := ""
-	for _, d := range []string{"from", "into"} {
+	for _, d := range []string{"into", "from"} {
 		if val, ok := args.Options[d]; ok && val != "" {
 			fmt.Println("val", val)
 
@@ -39,9 +39,9 @@ func main() {
 	// The logic here is that if no explicit `into` or `from` option was given
 	// then the first positional argument (read left from right) is the format
 	// and anything after that is the actual input, however if only 1 positional
-	// argument was given then that must be the input in which case we should all
-	// the possible translations, this is why we're checking format for emptiness
-	// twice
+	// argument was given then that must be the input in which case we should run
+	// all the possible translations, this is why we're checking format for
+	// emptiness twice
 	if format == "" {
 		if len(args.Positionals) > 1 {
 			format = args.Positionals[0]

--- a/parsers/number.go
+++ b/parsers/number.go
@@ -16,11 +16,11 @@ func NewNumberGroup() *NumberGroup {
 	return &NumberGroup{}
 }
 
-// CanParseIntoHuman determines if input is within bounds
+// CanParseFromMachine determines if input is within bounds
 // in that the input:
-// Contains only digits
-// Is >= 1000
-func (n *NumberGroup) CanParseIntoHuman(s string) (bool, error) {
+// 	Contains only digits
+// 	Is >= 1000
+func (n *NumberGroup) CanParseFromMachine(s string) (bool, error) {
 	if isMachineNumber(s) && len(s) >= 4 {
 		return true, nil
 	}
@@ -36,12 +36,12 @@ func (n *NumberGroup) CanParseIntoHuman(s string) (bool, error) {
 	return false, err
 }
 
-// CanParseFromHuman determines if input is within bounds
+// CanParseIntoMachine determines if input is within bounds
 // in that the input:
 // 	Should at least be the number 1 thousand
 // 	Can't have letters in it
 // 	Needs to have a comma in it
-func (n *NumberGroup) CanParseFromHuman(s string) (bool, error) {
+func (n *NumberGroup) CanParseIntoMachine(s string) (bool, error) {
 	if isDelimitedNumber(s) && len(s) >= 4 {
 		return true, nil
 	}
@@ -59,9 +59,9 @@ func (n *NumberGroup) CanParseFromHuman(s string) (bool, error) {
 	return false, err
 }
 
-// DoIntoHuman takes a string made up of contiguous "0-9" characters and
+// DoFromMachine takes a string made up of contiguous "0-9" characters and
 // returns number groupings
-func (n *NumberGroup) DoIntoHuman(s string) string {
+func (n *NumberGroup) DoFromMachine(s string) string {
 	// Figure out where to place commas
 	var buf strings.Builder
 	bufLen := len(s) - 1
@@ -85,7 +85,7 @@ func (n *NumberGroup) DoIntoHuman(s string) string {
 	return out.String()
 }
 
-// DoFromHuman ...
-func (n *NumberGroup) DoFromHuman(s string) string {
+// DoIntoMachine ...
+func (n *NumberGroup) DoIntoMachine(s string) string {
 	return strings.Replace(s, ",", "", -1)
 }

--- a/parsers/number_test.go
+++ b/parsers/number_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestNumberGroupCanParseIntoHuman(t *testing.T) {
+func TestNumberGroupCanParseFromMachine(t *testing.T) {
 	tests := []struct {
 		in  string
 		out bool
@@ -25,7 +25,7 @@ func TestNumberGroupCanParseIntoHuman(t *testing.T) {
 	numbergroup := NewNumberGroup()
 	for i, tt := range tests {
 		t.Run(tt.in, func(t *testing.T) {
-			got, err := numbergroup.CanParseIntoHuman(tt.in)
+			got, err := numbergroup.CanParseFromMachine(tt.in)
 			if got != tt.out {
 				t.Errorf("Case %d: Given = `%s` ; want `%t` ; got `%t`", i, tt.in, tt.out, got)
 			}
@@ -36,7 +36,7 @@ func TestNumberGroupCanParseIntoHuman(t *testing.T) {
 	}
 }
 
-func TestNumberGroupCanParseFromHuman(t *testing.T) {
+func TestNumberGroupCanParseIntoMachine(t *testing.T) {
 	tests := []struct {
 		in  string
 		out bool
@@ -52,7 +52,7 @@ func TestNumberGroupCanParseFromHuman(t *testing.T) {
 	numbergroup := NewNumberGroup()
 	for i, tt := range tests {
 		t.Run(tt.in, func(t *testing.T) {
-			got, err := numbergroup.CanParseFromHuman(tt.in)
+			got, err := numbergroup.CanParseIntoMachine(tt.in)
 			if got != tt.out {
 				t.Errorf("Case %d: Given = `%s` ; want `%t` ; got `%t`", i, tt.in, tt.out, got)
 			}
@@ -63,7 +63,7 @@ func TestNumberGroupCanParseFromHuman(t *testing.T) {
 	}
 }
 
-func TestNumberGroupDoIntoHuman(t *testing.T) {
+func TestNumberGroupDoFromMachine(t *testing.T) {
 	tests := []struct {
 		in  string
 		out string
@@ -84,7 +84,7 @@ func TestNumberGroupDoIntoHuman(t *testing.T) {
 	numbergroup := NewNumberGroup()
 	for i, tt := range tests {
 		t.Run(tt.in, func(t *testing.T) {
-			got := numbergroup.DoIntoHuman(tt.in)
+			got := numbergroup.DoFromMachine(tt.in)
 			if got != tt.out {
 				t.Errorf("Case %d: Given = `%s` ; want `%s` ; got `%s`", i, tt.in, tt.out, got)
 			}
@@ -92,7 +92,7 @@ func TestNumberGroupDoIntoHuman(t *testing.T) {
 	}
 }
 
-func TestNumberGroupDoFromHuman(t *testing.T) {
+func TestNumberGroupDoIntoMachine(t *testing.T) {
 	tests := []struct {
 		in  string
 		out string
@@ -111,7 +111,7 @@ func TestNumberGroupDoFromHuman(t *testing.T) {
 	numbergroup := NewNumberGroup()
 	for i, tt := range tests {
 		t.Run(tt.in, func(t *testing.T) {
-			got := numbergroup.DoFromHuman(tt.in)
+			got := numbergroup.DoIntoMachine(tt.in)
 			if got != tt.out {
 				t.Errorf("Case %d: Given = `%s` ; want `%s` ; got `%s`", i, tt.in, tt.out, got)
 			}

--- a/parsers/numword.go
+++ b/parsers/numword.go
@@ -62,13 +62,13 @@ func NewNumberWord() *NumberWord {
 	}
 }
 
-// CanParseIntoHuman ...
+// CanParseFromMachine ...
 // is it 4 or more characters? (e.g. is it => 1000)
 // is it a (delimited[,. ]) number?
 // is it less than the max?
 //  67 places plus delimiters = 88 char
 // everything else is not a number
-func (n *NumberWord) CanParseIntoHuman(s string) (bool, error) {
+func (n *NumberWord) CanParseFromMachine(s string) (bool, error) {
 	if (len(s) >= 4) && (len(s) <= 88) &&
 		(isMachineNumber(s) || isDelimitedNumber(s)) {
 		return true, nil
@@ -87,10 +87,10 @@ func (n *NumberWord) CanParseIntoHuman(s string) (bool, error) {
 	return false, err
 }
 
-// CanParseFromHuman ...
+// CanParseIntoMachine ...
 // is it a digit word combo? ( <number>[.tenths] <word> )
 // is the word in the trans table? (case insensitive)
-func (n *NumberWord) CanParseFromHuman(s string) (bool, error) {
+func (n *NumberWord) CanParseIntoMachine(s string) (bool, error) {
 	//
 	match, _ := regexp.MatchString(`^[0-9]+([.][0-9])? [a-zA-Z]+$`, s)
 	if match {
@@ -106,11 +106,11 @@ func (n *NumberWord) CanParseFromHuman(s string) (bool, error) {
 	return false, ErrNotADigitWordCombo
 }
 
-// DoIntoHuman ...
+// DoFromMachine ...
 // Can accept delimited numbers
 // Uses NumberGroup to make an array
 // Rounds second group to nearest hundreds (i.e. 1 decimal place)
-func (n *NumberWord) DoIntoHuman(s string) string {
+func (n *NumberWord) DoFromMachine(s string) string {
 	// Strip delimiters
 	r := regexp.MustCompile("[^0-9]")
 	s = r.ReplaceAllString(s, "")
@@ -132,11 +132,11 @@ func (n *NumberWord) DoIntoHuman(s string) string {
 	return out.String()
 }
 
-// DoFromHuman ...
+// DoIntoMachine ...
 // Only works with highest power
 // and first digit (e.g. 100.3 Billion, not 100,300 Million)
 // Returns a numeric string e.g. 1 thousand => 1000
-func (n *NumberWord) DoFromHuman(s string) string {
+func (n *NumberWord) DoIntoMachine(s string) string {
 	num, word := splitHumanNumberWord(s)
 	var power int
 

--- a/parsers/numword.go
+++ b/parsers/numword.go
@@ -116,7 +116,7 @@ func (n *NumberWord) DoIntoHuman(s string) string {
 	s = r.ReplaceAllString(s, "")
 
 	numgroup := NewNumberGroup()
-	numbers := strings.Split(numgroup.DoIntoHuman(s), ",")
+	numbers := strings.Split(numgroup.DoFromMachine(s), ",")
 
 	var out strings.Builder
 	out.WriteString(numbers[0])

--- a/parsers/numword_test.go
+++ b/parsers/numword_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestNumberWordCanParseIntoHuman(t *testing.T) {
+func TestNumberWordCanParseFromMachine(t *testing.T) {
 	tests := []struct {
 		in  string
 		out bool
@@ -33,7 +33,7 @@ func TestNumberWordCanParseIntoHuman(t *testing.T) {
 	numword := NewNumberWord()
 	for i, tt := range tests {
 		t.Run(tt.in, func(t *testing.T) {
-			got, err := numword.CanParseIntoHuman(tt.in)
+			got, err := numword.CanParseFromMachine(tt.in)
 			if got != tt.out {
 				t.Errorf("Case %d: Given = `%s` ; want `%t` ; got `%t`", i, tt.in, tt.out, got)
 			}
@@ -44,7 +44,7 @@ func TestNumberWordCanParseIntoHuman(t *testing.T) {
 	}
 }
 
-func TestNumberWordCanParseFromHumans(t *testing.T) {
+func TestNumberWordCanParseIntoMachine(t *testing.T) {
 	tests := []struct {
 		in  string
 		out bool
@@ -78,7 +78,7 @@ func TestNumberWordCanParseFromHumans(t *testing.T) {
 	numword := NewNumberWord()
 	for i, tt := range tests {
 		t.Run(tt.in, func(t *testing.T) {
-			got, err := numword.CanParseFromHuman(tt.in)
+			got, err := numword.CanParseIntoMachine(tt.in)
 			if got != tt.out {
 				t.Errorf("Case %d: Given = `%s` ; want `%t` ; got `%t`", i, tt.in, tt.out, got)
 			}
@@ -89,7 +89,7 @@ func TestNumberWordCanParseFromHumans(t *testing.T) {
 	}
 }
 
-func TestNumberWordDoIntoHuman(t *testing.T) {
+func TestNumberWordDoFromMachine(t *testing.T) {
 	tests := []struct {
 		in  string
 		out string
@@ -114,7 +114,7 @@ func TestNumberWordDoIntoHuman(t *testing.T) {
 	numword := NewNumberWord()
 	for i, tt := range tests {
 		t.Run(tt.in, func(t *testing.T) {
-			got := numword.DoIntoHuman(tt.in)
+			got := numword.DoFromMachine(tt.in)
 			if got != tt.out {
 				t.Errorf("Case %d: Given = `%s` ; want `%s` ; got `%s`", i, tt.in, tt.out, got)
 			}
@@ -122,7 +122,7 @@ func TestNumberWordDoIntoHuman(t *testing.T) {
 	}
 }
 
-func TestNumberWordDoFromHuman(t *testing.T) {
+func TestNumberWordDoIntoMachine(t *testing.T) {
 	tests := []struct {
 		in  string
 		out string
@@ -140,7 +140,7 @@ func TestNumberWordDoFromHuman(t *testing.T) {
 	numword := NewNumberWord()
 	for i, tt := range tests {
 		t.Run(tt.in, func(t *testing.T) {
-			got := numword.DoFromHuman(tt.in)
+			got := numword.DoIntoMachine(tt.in)
 			if got != tt.out {
 				t.Errorf("Case %d: Given = `%s` ; want `%s` ; got `%s`", i, tt.in, tt.out, got)
 			}

--- a/parsers/parsers.go
+++ b/parsers/parsers.go
@@ -7,10 +7,10 @@ import (
 
 // Parser is the contract that the main command line application will use
 type Parser interface {
-	CanParseIntoHuman(string) (bool, error)
-	CanParseFromHuman(string) (bool, error)
-	DoIntoHuman(string) string
-	DoFromHuman(string) string
+	CanParseIntoMachine(string) (bool, error)
+	CanParseFromMachine(string) (bool, error)
+	DoIntoMachine(string) string
+	DoFromMachine(string) string
 }
 
 // General purpose errors

--- a/parsers/parsers.go
+++ b/parsers/parsers.go
@@ -29,19 +29,19 @@ func NewEmpty() *Empty {
 
 type Empty struct{}
 
-func (e *Empty) CanParseIntoHuman(string) (bool, error) {
+func (e *Empty) CanParseIntoMachine(string) (bool, error) {
 	return true, nil
 }
 
-func (e *Empty) CanParseFromHuman(string) (bool, error) {
+func (e *Empty) CanParseFromMachine(string) (bool, error) {
 	return true, nil
 }
 
-func (e *Empty) DoIntoHuman(string) string {
+func (e *Empty) DoIntoMachine(string) string {
 	return "Not Yet Implemented"
 }
 
-func (e *Empty) DoFromHuman(string) string {
+func (e *Empty) DoFromMachine(string) string {
 	return "Not Yet Implemented"
 }
 

--- a/parsers/size.go
+++ b/parsers/size.go
@@ -160,8 +160,8 @@ func NewSize(input interface{}) *Size {
 	}
 }
 
-// CanParseIntoHuman determines if string is valid for this parser
-func (sz *Size) CanParseIntoHuman(s string) bool {
+// CanParseFromMachine determines if string is valid for this parser
+func (sz *Size) CanParseFromMachine(s string) bool {
 	if len(s) < 4 {
 		return false
 	}
@@ -170,16 +170,16 @@ func (sz *Size) CanParseIntoHuman(s string) bool {
 	return !match
 }
 
-// CanParseFromHuman determines if the user input can be handled by this parser.
+// CanParseIntoMachine determines if the user input can be handled by this parser.
 // The gist is that it should allow any number followed by a known suffix,
 // with no spaces in between the number of the suffix, ie:
 // 	1234654<suffix>
-func (sz *Size) CanParseFromHuman(s string) bool {
+func (sz *Size) CanParseIntoMachine(s string) bool {
 	// Get the suffix passed
 	r := regexp.MustCompile(`(?i)[a-z]+$`)
 	inputSuffix := r.FindString(s)
 
-	// Does this suffix correspond the the units we're using?
+	// Does this suffix correspond to the units we're using?
 	allowed := false
 	for _, v := range suffixes[sz.units] {
 		if v == strings.ToLower(inputSuffix) {
@@ -190,7 +190,7 @@ func (sz *Size) CanParseFromHuman(s string) bool {
 	return allowed
 }
 
-func (sz *Size) DoIntoHuman(s string) string {
+func (sz *Size) DoFromMachine(s string) string {
 
 	opts := sz.trans[len(s)]
 	n, _ := strconv.ParseFloat(s, 64)
@@ -201,7 +201,7 @@ func (sz *Size) DoIntoHuman(s string) string {
 	return fmt.Sprintf("%.1f%s", res, opts.suffix)
 }
 
-func (sz *Size) DoFromHuman(s string) string {
+func (sz *Size) DoIntoMachine(s string) string {
 	// Pull out the number and the suffix from the string
 	r := regexp.MustCompile(`([0-9]+)([a-zA-Z]+)`)
 	match := r.FindStringSubmatch(s)

--- a/parsers/size_test.go
+++ b/parsers/size_test.go
@@ -31,7 +31,7 @@ func TestDefaultUnitIsSet(t *testing.T) {
 	}
 }
 
-func TestSizeCanParseIntoHuman(t *testing.T) {
+func TestSizeCanParseFromMachine(t *testing.T) {
 	tests := []struct {
 		in  string
 		out bool
@@ -49,7 +49,7 @@ func TestSizeCanParseIntoHuman(t *testing.T) {
 	sizeP := NewSize(nil)
 	for i, tt := range tests {
 		t.Run(tt.in, func(t *testing.T) {
-			got := sizeP.CanParseIntoHuman(tt.in)
+			got := sizeP.CanParseFromMachine(tt.in)
 			if got != tt.out {
 				t.Errorf("Case %d: Given = `%s` ; want `%t` ; got `%t`", i, tt.in, tt.out, got)
 			}
@@ -57,22 +57,21 @@ func TestSizeCanParseIntoHuman(t *testing.T) {
 	}
 }
 
-func TestCanParseFromHuman(t *testing.T) {
+func TestCanParseIntoMachine(t *testing.T) {
 	tests := []struct {
 		units string
 		in    string
 		out   bool
 	}{
 		// Note that the number portion of the iput is picked at random in the test
-		// table loop. When reading these test cases, you shoul read as:
+		// table loop. When reading these test cases, you should them read as:
 		//
 		// 	"$some-gen-number + <in>" -> <out>
 		//
-		// In order to save some redundancy, every upper/lower case combination
-		// herein is generated tested as well. So when we see a letter or pairing
+		// // @TODO the following isn't happening, it should be added
+		// In order to save some redundancy, every upper/lower letter case combination
+		// is generated and tested as well. So when we see a letter or pairing
 		// of letters like say `KB`, that case will expanded to `kb, KB, kB, Kb`.
-		// Basically the unit portion of the input is case insensitive all the way
-		// around
 		//
 		// SI Units
 		// Symbols
@@ -122,7 +121,7 @@ func TestCanParseFromHuman(t *testing.T) {
 		{"iec", "exbi", true},
 		{"iec", "zebi", true},
 		{"iec", "yobi", true},
-		// Nonse
+		// Nonsense
 		{"iec", "xafadfa", false},
 		{"si", "234Af", false},
 	}
@@ -132,7 +131,7 @@ func TestCanParseFromHuman(t *testing.T) {
 		t.Run(tt.in, func(t *testing.T) {
 			num := rand.Intn(10_000_000)
 			input := fmt.Sprintf("%d%s", num, tt.in)
-			got := sizeP.CanParseFromHuman(input)
+			got := sizeP.CanParseIntoMachine(input)
 			if got != tt.out {
 				t.Errorf("Case %d: Given = `%s` ; want `%t` ; got `%t`", i, tt.in, tt.out, got)
 			}
@@ -140,7 +139,7 @@ func TestCanParseFromHuman(t *testing.T) {
 	}
 }
 
-func TestSizeDoIntoHumanSI(t *testing.T) {
+func TestSizeDoFromMachine(t *testing.T) {
 	tests := []struct {
 		in  string
 		out string
@@ -179,7 +178,7 @@ func TestSizeDoIntoHumanSI(t *testing.T) {
 	sizeP := NewSize("si")
 	for i, tt := range tests {
 		t.Run(tt.in, func(t *testing.T) {
-			got := sizeP.DoIntoHuman(tt.in)
+			got := sizeP.DoFromMachine(tt.in)
 			if got != tt.out {
 				t.Errorf("Case %d: Given = `%s` ; want `%s` ; got `%s`", i, tt.in, tt.out, got)
 			}
@@ -187,7 +186,7 @@ func TestSizeDoIntoHumanSI(t *testing.T) {
 	}
 }
 
-func TestSizeDoIntoHumanIEC(t *testing.T) {
+func TestSizeDoFromMachineIEC(t *testing.T) {
 	tests := []struct {
 		in  string
 		out string
@@ -227,7 +226,7 @@ func TestSizeDoIntoHumanIEC(t *testing.T) {
 	sizeP := NewSize("iec")
 	for i, tt := range tests {
 		t.Run(tt.in, func(t *testing.T) {
-			got := sizeP.DoIntoHuman(tt.in)
+			got := sizeP.DoFromMachine(tt.in)
 			if got != tt.out {
 				t.Errorf("Case %d: Given = `%s` ; want `%s` ; got `%s`", i, tt.in, tt.out, got)
 			}
@@ -237,10 +236,9 @@ func TestSizeDoIntoHumanIEC(t *testing.T) {
 
 // This series is a bit different given that `NewSize` determines the input
 // type or standard to use based on the suffix that is passed to it.
-// These aren't checking that logic however (other tests do that @TODO add
-// tests to cmd.Size) hence the passing of the `inputType` parameter in the
-// test cases
-func TestSizeDoFromHuman(t *testing.T) {
+// These aren't checking that logic however (other tests do that)
+// hence the passing of the `inputType` parameter in the test cases
+func TestSizeDoIntoMachine(t *testing.T) {
 	tests := []struct {
 		inputType interface{}
 		in        string
@@ -266,7 +264,7 @@ func TestSizeDoFromHuman(t *testing.T) {
 	for i, tt := range tests {
 		sizeP := NewSize(tt.inputType)
 		t.Run(tt.in, func(t *testing.T) {
-			got := sizeP.DoFromHuman(tt.in)
+			got := sizeP.DoIntoMachine(tt.in)
 			if got != tt.out {
 				t.Errorf("Case %d: Given = `%s` ; want `%s` ; got `%s`", i, tt.in, tt.out, got)
 			}


### PR DESCRIPTION
Before the word "machine" was implied in all the methods, now the word that's implied is "human", which makes a little more sense since the tool is called human. 

This helps the code line up to the usage and documentation which will make it easier to add new stuff since the operation implied when saying "from format foo" and "into format foo" will match the method names

- docs: fix typos
- refactor(parsers): Invert interface meaning
- refactor(parsers.number): invert direction
- fix(parsers): invert direction in the empty impl
- refactor(parsers.numword): invert direction
- refactor(parsers.size): invert direction
- refactor(cmd): invert direction
- refactor: change defaults at the entrypoint

----

All test are passing 

```
human on  invert-direction via 🐹 v1.14.4
❯ go test ./...
?       github.com/andres-lowrie/human  [no test files]
ok      github.com/andres-lowrie/human/cmd      (cached)
ok      github.com/andres-lowrie/human/parsers  (cached)

```

resolves: #17 